### PR TITLE
Fixed broken symlinks

### DIFF
--- a/libminifb/src/gl/MiniFB_GL.c
+++ b/libminifb/src/gl/MiniFB_GL.c
@@ -1,1 +1,1 @@
-./upstream/src/gl/MiniFB_GL.c
+../../../upstream/src/gl/MiniFB_GL.c

--- a/libminifb/src/gl/MiniFB_GL.h
+++ b/libminifb/src/gl/MiniFB_GL.h
@@ -1,1 +1,1 @@
-./upstream/src/gl/MiniFB_GL.h
+../../../upstream/src/gl/MiniFB_GL.h

--- a/libminifb/src/x11/WindowData_X11.h
+++ b/libminifb/src/x11/WindowData_X11.h
@@ -1,1 +1,1 @@
-./upstream/src/x11/WindowData_X11.h
+../../../upstream/src/x11/WindowData_X11.h

--- a/libminifb/src/x11/X11MiniFB.c
+++ b/libminifb/src/x11/X11MiniFB.c
@@ -1,1 +1,1 @@
-./upstream/src/x11/X11MiniFB.c
+../../../upstream/src/x11/X11MiniFB.c


### PR DESCRIPTION
This fixes some symlinks being broken: they were not relative to the directory where the symlink files.

This is not enough to fix the build using `build2` as there sems to be headers missing but included like `X11/Xlib.h`

But at least it does fix the issues where `build2` can't find the targets referenced in buildfiles.